### PR TITLE
Fixed typo? has so effects -> has no effects

### DIFF
--- a/book/cha9.tex
+++ b/book/cha9.tex
@@ -531,7 +531,7 @@ the instance variables for its type.
 by reference but that cannot be modified.
 
 \item[pure function:]  A function whose result depends only on its
-parameters, and that has so effects other than returning
+parameters, and that has no effects other than returning
 a value.
 
 \item[functional programming style:]  A style of program design


### PR DESCRIPTION
Not 100% sure, but I think this was meant to be read as "has no effects"?
